### PR TITLE
Align code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/badge/licence-BSD--3--Clause-brightgreen.svg)]()
 
 This Is an Open Source news sharing application in Django.
-Users can share ,comment and vote for news.
+Users can share, comment and vote for news.
 
 # Getting Started
 ---
@@ -21,19 +21,20 @@ Users can share ,comment and vote for news.
    ```pip install -r requirements.py```
    
  * Make any migartions if Models.py changed 
- 
-  ```python manage.py makemigrations```
+  
+   ```python manage.py makemigrations```
+  
 * Then apply those migartions
 
-  ```python manage.py migrate```
+   ```python manage.py migrate```
   
 * Run the app by
 
- ```python manage.py runserver```
+  ```python manage.py runserver```
  
 * Open Your browser at
 
- ```localhost:8080```
+  ```localhost:8080```
 
 # License
 The project is under BSD-3-Clause License - see the [License.md](https://github.com/thecodinghub/news-for-good/blob/master/LICENSE) file for details.


### PR DESCRIPTION
In the previous version the code blocks had not the same indent. Compare the rendered preview from Github.